### PR TITLE
docs: fix installation sources path

### DIFF
--- a/guides/installation.md
+++ b/guides/installation.md
@@ -58,7 +58,7 @@ defp html_helpers do
 end
 ```
 
-5. LiveReact comes with a handy mix task to setup all the required files. It won't alter any files you already have in your project, you need to adjust them on your own by looking at the [sources](https://github.com/mrdotb/live_react/tree/main/assets/js/copy). Additional instructions how to adjust `package.json` can be found at the end of this page.
+5. LiveReact comes with a handy mix task to setup all the required files. It won't alter any files you already have in your project, you need to adjust them on your own by looking at the [sources](https://github.com/mrdotb/live_react/tree/main/assets/copy). Additional instructions how to adjust `package.json` can be found at the end of this page.
 
 It will create:
 


### PR DESCRIPTION
# Contributor checklist

- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
