### PR TITLE
feat: Added SSR duration logging to example app

### DIFF
--- a/live_react_examples/lib/live_react_examples/application.ex
+++ b/live_react_examples/lib/live_react_examples/application.ex
@@ -19,6 +19,9 @@ defmodule LiveReactExamples.Application do
       LiveReactExamplesWeb.Endpoint
     ]
 
+    # Set up LiveReactExamples.Telemetry
+    LiveReactExamples.Telemetry.setup()
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: LiveReactExamples.Supervisor]

--- a/live_react_examples/lib/live_react_examples/telemetry.ex
+++ b/live_react_examples/lib/live_react_examples/telemetry.ex
@@ -1,0 +1,18 @@
+defmodule LiveReactExamples.Telemetry do
+  require Logger
+
+  def setup() do
+    :ok =
+      :telemetry.attach(
+        "live-react-ssr-logger",
+        [:live_react, :ssr, :stop],
+        &LiveReactExamples.Telemetry.handle_event/4,
+        nil
+      )
+  end
+
+  def handle_event([:live_react, :ssr, :stop], %{duration: duration}, metadata, _config) do
+    duration_ms = System.convert_time_unit(duration, :native, :microsecond)
+    Logger.info("SSR completed for component: #{metadata.component} in #{duration_ms}µs")
+  end
+end


### PR DESCRIPTION
# Summary

I've added logs to SSR rendering to figure out if it's the reason for slowdowns. You should be able to see them either in a local app console or fly logs. 

# Contributor checklist

- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
