### PR TITLE
feat: Add inner_block slot support pass as HTML

### DIFF
--- a/assets/js/live_react/hooks.js
+++ b/assets/js/live_react/hooks.js
@@ -6,6 +6,20 @@ function getAttributeJson(el, attributeName) {
   return data ? JSON.parse(data) : {};
 }
 
+function getChildren(hook) {
+  const dataSlots = getAttributeJson(hook.el, "data-slots");
+
+  if (!dataSlots?.default) {
+    return [];
+  }
+
+  return [
+    React.createElement("div", {
+      dangerouslySetInnerHTML: { __html: atob(dataSlots.default).trim() },
+    }),
+  ];
+}
+
 function getProps(hook) {
   return {
     ...getAttributeJson(hook.el, "data-props"),
@@ -21,7 +35,13 @@ function getProps(hook) {
 export function getHooks(components) {
   const ReactHook = {
     _render() {
-      this._root.render(React.createElement(this._Component, getProps(this)));
+      this._root.render(
+        React.createElement(
+          this._Component,
+          getProps(this),
+          ...getChildren(this)
+        )
+      );
     },
     mounted() {
       const componentName = this.el.getAttribute("data-name");
@@ -36,7 +56,11 @@ export function getHooks(components) {
       if (isSSR) {
         this._root = ReactDOM.hydrateRoot(
           this.el,
-          React.createElement(this._Component, getProps(this)),
+          React.createElement(
+            this._Component,
+            getProps(this),
+            ...getChildren(this)
+          )
         );
       } else {
         this._root = ReactDOM.createRoot(this.el);

--- a/assets/js/live_react/server.mjs
+++ b/assets/js/live_react/server.mjs
@@ -6,14 +6,27 @@ function Wrapper({ children }) {
 }
 
 export function getRender(components) {
-  return function render(name, props) {
+  return function render(name, props, slots) {
     const Component = components[name];
     if (!Component) {
       throw new Error(`Component "${name}" not found`);
     }
 
+    let children = [];
+    if (slots?.default) {
+      children.push(
+        React.createElement("div", {
+          dangerouslySetInnerHTML: { __html: slots.default.trim() },
+        })
+      );
+    }
+
     // The Component need to be wrapped to prevent useState useEffect error which can't be root component
-    const componentInstance = React.createElement(Component, props);
+    const componentInstance = React.createElement(
+      Component,
+      props,
+      ...children
+    );
     const content = React.createElement(Wrapper, null, componentInstance);
 
     // https://react.dev/reference/react-dom/server/renderToString

--- a/assets/js/live_react/vite-plugin.js
+++ b/assets/js/live_react/vite-plugin.js
@@ -84,7 +84,11 @@ function liveReactPlugin(opts = {}) {
           jsonMiddleware(req, res, async () => {
             try {
               const render = (await server.ssrLoadModule(entrypoint)).render;
-              const html = await render(req.body.name, req.body.props);
+              const html = await render(
+                req.body.name,
+                req.body.props,
+                req.body.slots
+              );
               res.end(html);
             } catch (e) {
               server.ssrFixStacktrace(e);

--- a/lib/live_react/slots.ex
+++ b/lib/live_react/slots.ex
@@ -1,0 +1,38 @@
+defmodule LiveReact.Slots do
+  @moduledoc false
+
+  import Phoenix.Component
+
+  @doc false
+  def rendered_slot_map(assigns) do
+    for(
+      {key, [%{__slot__: _}] = slot} <- assigns,
+      into: %{},
+      do:
+        case(key) do
+          :inner_block ->
+            {:default, render(%{slot: slot})}
+
+          slot_name ->
+            raise "Unsupported slot: #{slot_name}, only one default slot is supported, passed as React children."
+        end
+    )
+  end
+
+  @doc false
+  def base_encode_64(assigns) do
+    for {key, value} <- assigns, into: %{}, do: {key, Base.encode64(value)}
+  end
+
+  @doc false
+  defp render(assigns) do
+    ~H"""
+    <%= if assigns[:slot] do %>
+      <%= render_slot(@slot) %>
+    <% end %>
+    """
+    |> Phoenix.HTML.Safe.to_iodata()
+    |> List.to_string()
+    |> String.trim()
+  end
+end

--- a/lib/live_react/ssr.ex
+++ b/lib/live_react/ssr.ex
@@ -19,6 +19,7 @@ defmodule LiveReact.SSR do
 
   @type component_name :: String.t()
   @type props :: %{optional(String.t() | atom) => any}
+  @type slots :: %{optional(String.t()) => any}
 
   @typedoc """
   A render response which should have shape
@@ -29,20 +30,20 @@ defmodule LiveReact.SSR do
   """
   @type render_response :: %{optional(String.t() | atom) => any}
 
-  @callback render(component_name, props) :: render_response | no_return
+  @callback render(component_name, props, slots) :: render_response | no_return
 
-  @spec render(component_name, props) :: render_response | no_return
-  def render(name, props) do
+  @spec render(component_name, props, slots) :: render_response | no_return
+  def render(name, props, slots) do
     case Application.get_env(:live_react, :ssr_module, nil) do
       nil ->
         %{preloadLinks: "", html: ""}
 
       mod ->
-        meta = %{component: name, props: props}
+        meta = %{component: name, props: props, slots: slots}
 
         body =
           :telemetry.span([:live_react, :ssr], meta, fn ->
-            {mod.render(name, props), meta}
+            {mod.render(name, props, slots), meta}
           end)
 
         with body when is_binary(body) <- body do

--- a/lib/live_react/ssr/node_js.ex
+++ b/lib/live_react/ssr/node_js.ex
@@ -9,13 +9,17 @@ defmodule LiveReact.SSR.NodeJS do
 
   @behaviour LiveReact.SSR
 
-  def render(name, props) do
+  def render(name, props, slots) do
     filename = Application.get_env(:live_react, :ssr_filepath, "./react-components/server.js")
 
     if Code.ensure_loaded?(NodeJS) do
       try do
         # Dynamically apply the NodeJS.call!/3 to avoid compiler warning
-        apply(NodeJS, :call!, [{filename, "render"}, [name, props], [binary: true, esm: true]])
+        apply(NodeJS, :call!, [
+          {filename, "render"},
+          [name, props, slots],
+          [binary: true, esm: true]
+        ])
       catch
         :exit, {:noproc, _} ->
           message = """

--- a/lib/live_react/ssr/vite_js.ex
+++ b/lib/live_react/ssr/vite_js.ex
@@ -16,8 +16,8 @@ defmodule LiveReact.SSR.ViteJS do
 
   @behaviour LiveReact.SSR
 
-  def render(name, props) do
-    data = Jason.encode!(%{name: name, props: props})
+  def render(name, props, slots) do
+    data = Jason.encode!(%{name: name, props: props, slots: slots})
     url = vite_path("/ssr_render")
     params = {String.to_charlist(url), [], ~c"application/json", data}
 


### PR DESCRIPTION
👋 @mrdotb - not sure if you wanna go this route, but I found this useful in my project, I've added some basic slot interop with react where we can pass the inner_block as `{ children }` to the component, though it happens as HTML so providers etc won't work with nested react components (pretty similar to how live_vue does it)

# Contributor checklist

- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
