### PR TITLE
fix: Ensure app.ts entrypoints can be used with @react-refresh

### DIFF
--- a/lib/live_react/reload.ex
+++ b/lib/live_react/reload.ex
@@ -20,7 +20,11 @@ defmodule LiveReact.Reload do
       )
       |> assign(
         :javascripts,
-        for(path <- assigns.assets, String.ends_with?(path, ".js"), do: path)
+        for(
+          path <- assigns.assets,
+          String.ends_with?(path, ".js") || String.ends_with?(path, ".ts"),
+          do: path
+        )
       )
 
     # TODO - maybe make it configurable in other way than by presence of vite_host config?


### PR DESCRIPTION
## Why

If a `/js/app.ts` entrypoint is provided to the `LiveReact.Reload.vite_assets/1` method, it won't have a corresponding `<script>` tag generated in development for hot reloads.

## What changed

Quick fix to look for `.ts` files as well.