### PR TITLE
fix: add missing type for useLiveReact hook

### DIFF
--- a/assets/js/live_react/index.d.mts
+++ b/assets/js/live_react/index.d.mts
@@ -18,3 +18,5 @@ export interface LiveProps {
   upload: (name: string, files: FileList | File[]) => void;
   uploadTo: (target: string, name: string, files: FileList | File[]) => void;
 }
+
+export function useLiveReact(): LiveProps;


### PR DESCRIPTION
I am toying around in a project using typescript and noticed a type error when importing `useLiveReact`: 

```ts
import { useLiveReact } from "live_react"; // 1. Module '"live_react"' has no exported member 'useLiveReact'. [2305]
```