### PR TITLE
fix: add type export for getHooks function

### DIFF
--- a/assets/js/live_react/index.d.mts
+++ b/assets/js/live_react/index.d.mts
@@ -1,3 +1,6 @@
+import React from "react";
+import { ViewHookInterface } from "phoenix_live_view";
+
 export interface LiveProps {
   pushEvent: (
     event: string,
@@ -20,3 +23,17 @@ export interface LiveProps {
 }
 
 export function useLiveReact(): LiveProps;
+
+interface ReactHookType {
+  _render: () => void;
+  mounted: () => void;
+  updated: () => void;
+  destroyed: () => void;
+}
+
+/**
+ * Creates React hook handlers for Phoenix LiveView
+ */
+export function getHooks(components: Record<string, React.ComponentType<any>>): {
+  ReactHook: ReactHookType;
+};


### PR DESCRIPTION
Makes it possible to integrate if using typescript as entrypoint. (registering hooks in `app.ts`) 

# Contributor checklist

- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
      For example: `fix: Multiply by appropriate coefficient`, or
      `feat(Calculator): Correctly preserve history`
      Any explanation or long form information in your commit message should be
      in a separate paragraph, separated by a blank line from the primary message
